### PR TITLE
Test: Add publish-to-latest workflow for 5.0 English documents

### DIFF
--- a/.github/workflows/build-documents.yml
+++ b/.github/workflows/build-documents.yml
@@ -49,3 +49,10 @@ jobs:
       - build-image
       - filters
     uses: owasp/asvs/.github/workflows/create-5.0-outputs.yml@master
+
+  publish-v5-latest:
+    if: ${{ always() && needs.filters.outputs.v5 == 'true' }}
+    needs:
+      - build-v5
+      - filters
+    uses: ./.github/workflows/publish-5.0-english-latest.yml

--- a/.github/workflows/publish-5.0-english-latest.yml
+++ b/.github/workflows/publish-5.0-english-latest.yml
@@ -1,0 +1,23 @@
+# This workflow uploads the generated English 5.0 documents to the 'latest' GitHub release.
+name: Publish 5.0 English Docs to Latest Release
+
+on:
+  workflow_call:
+
+jobs:
+  publish-5-0-english-latest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download 5.0 English artifact
+        uses: actions/download-artifact@v4.1.7
+        with:
+          name: ASVS 5.0.0
+          path: ./asvs-5.0-english
+      - name: Upload to 'latest' GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: latest
+          name: Latest 5.0 English Documents
+          files: ./asvs-5.0-english/**
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds and integrates a workflow to publish the generated English 5.0 documents to the continuously updated 'latest' GitHub release. This is for testing the new release automation process as described in the plan.